### PR TITLE
Addition of new button and function for prusa, if the command M862.2%…

### DIFF
--- a/src/index.htm
+++ b/src/index.htm
@@ -352,7 +352,8 @@
 									  Copy </a> 
                             <button type="button" class="btn btn-default" id="btn-auto-check" title="send M115 and auto mount SD ,unmount SD to check Node's core cunction"> 
                                 Auto Check
-</button>                             
+</button>
+                            <button type="button" class="btn btn-default hidden" id="mbtn-prusa-disablereset" title="send ;C32u2_RMD command to turn off the Prusa setting to restart when USB is connected">Disable Prusa Reset when USB Connected</button>                             
                         </div>                         
                     </div>                     
                     <div class="row"> 
@@ -376,8 +377,7 @@
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                         <h4 class="modal-title" id="myModalLabel">Modal title</h4>
                     </div>

--- a/src/script.js
+++ b/src/script.js
@@ -25,6 +25,17 @@ function between_text (txt_to_search, start_tag, end_tag) {
 }
 
 
+function check_if_prusa_MK(){
+  var prusa_gcode = 'M862.2%20Q'
+  var tt_url = '/gcode?gc=' + prusa_gcode;
+  xmlHttp = new XMLHttpRequest();
+  xmlHttp.open('GET', tt_url);
+  xmlHttp.send();
+
+
+}
+
+
 /******
  * file upload and list
  */
@@ -645,7 +656,7 @@ source.addEventListener(
     //Specific to leveraging Prusa specfici M37 Gcode that returns percentage back
     var pruse_m37_result = obj.includes("NORMAL MODE");
     if (pruse_m37_result) {
-      var currentprusaPercent = between_text(nodeobj, "Percent done: ", ";");
+      var currentprusaPercent = between_text(obj, "Percent done: ", ";");
       var percent_update = document.getElementById("print-progess");
       percent_update.innerHTML = currentprusaPercent.toString();
       if (currentprusaPercent.toString() === "100") {
@@ -653,6 +664,13 @@ source.addEventListener(
       }
     }
 
+
+    //Check if call contains Prusa MK3S series printer confirmation to display the button
+    if (obj.endsWith('302')|| obj.endsWith('20302'))
+  {
+      $('#mbtn-prusa-disablereset').removeClass('hidden')
+
+  }
 
 
 
@@ -753,6 +771,7 @@ const msetSPIButton = document.getElementById('mbtn-setspi');
 const msetSDIOButton = document.getElementById('mbtn-setsdio');
 
 const findDeviceButton = document.getElementById('mbtn-findDevice');
+const cancelPrusaUSBButton = document.getElementById('mbtn-prusa-disablereset');
 
 
 xpButton.onclick = () => {
@@ -963,6 +982,14 @@ autoCheckButton.onclick = () => {
 };
 
 
+cancelPrusaUSBButton.onclick = () => {
+  
+  var cmd = ';C32u2_RMD';
+  sendGcode(cmd);
+
+};
+
+
 
 findDeviceButton.onclick = () => {
   var tt_url = '/find'
@@ -982,7 +1009,7 @@ findDeviceButton.onclick = () => {
 }
 
 
-
+check_if_prusa_MK()
 
 
 


### PR DESCRIPTION
Addition of new button and function for prusa, if the command M862.2%20Q' returns either 302 or 20302 in the event log this will show the disable USB restart button which will then enable them to click the button to run the ;C32u2_RMD command via the API for them.

If no matching is found then the button is not displayed

![image](https://user-images.githubusercontent.com/56988354/207228296-13cca5c5-269b-4632-b6e0-38046a485004.png)
